### PR TITLE
Genquery iterator for Python Rule Engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,10 @@ install(
   )
 
 install(
-    FILES ${CMAKE_SOURCE_DIR}/core.py.template ${CMAKE_SOURCE_DIR}/session_vars.py
+    FILES 
+     ${CMAKE_SOURCE_DIR}/core.py.template
+     ${CMAKE_SOURCE_DIR}/session_vars.py
+     ${CMAKE_SOURCE_DIR}/genquery.py
   DESTINATION etc/irods
   )
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This C++ plugin provides the iRODS platform a rule engine that allows iRODS rule
 
 # Build
 
-Building the iRODS Python Rule Engine Plugin requires version 4.2.1 of the iRODS software from github (http://github.com/irods/irods).
+Building the iRODS Python Rule Engine Plugin requires version 4.2.1+ of the iRODS software from github (http://github.com/irods/irods).
 
 ```
 cd irods_rule_engine_plugin_python
@@ -24,7 +24,9 @@ The packages produced by CMake will install the Python plugin shared object file
 
 After installing the plugin, `/etc/irods/server_config.json` needs to be configured to use the plugin.
 
-Add a new stanza to the "rule_engines" array within `server_config.json`:
+Python rules will be loaded from `core.py` (located at `/etc/irods/core.py.template` in a default installation).
+
+To activate the plugin, add a new stanza to the "rule_engines" array within `server_config.json`:
 
 ```json
 {
@@ -36,11 +38,19 @@ Add a new stanza to the "rule_engines" array within `server_config.json`:
 
 Adding the Python Rule Engine Plugin stanza above the default "irods_rule_engine_plugin-irods_rule_language" stanza will allow any defined Python rules to take precedence over any similarly named rules in the iRODS Rule Language.
 
-Python rules will be loaded from `core.py` (located at `/etc/irods/core.py` in a default installation).
+As soon as the stanza is inserted, the iRODS core expects a Python source code module to exist at the path `/etc/irods/core.py`. Once imported by the iRODS server and successfully compile to a Python byte-code file bearing the ".pyc" extension, any functions in the module will be callable as rules as long as they conform to a  calling convention
+```
+def a_python_rule( rule_args , callback , rei ):
+  # ... Python code to be executed in the rule context...
+```
+although the parameters need not be explicit or even named as they are here; they could in fact be collapsed into a parameter tuple, as in **pyfn(\*x)**. The first argument above, `rule_args`, is a tuple containing the optional, positional parameters fed to the rule function by its caller; these same parameters may be written to, with the effect that the written values will be returned to the caller. The `callback` object is effectively a gateway through which other rules (even those managed by other rule engine plugins) and microservices may be called. Finally, `rei` (also known as "rule exec info") is an object carrying iRODS-related context for the current rule call, including e.g. session variables.
 
-# Other
+When the plugin is freshly installed, a file `core.py.template` will exist in the directory
+`/etc/irods`. This may be copied to `/etc/irods/core.py` , or else an empty `core.py` can be created at that path if the user prefers to begin from scratch.
 
-- The example `core.py` file in this repository contains a Python implementation of all static policy enforcement points (PEPs) from a default `core.re` rulebase.
+# Minor Notes to the Python RE Plugin
+
+- The example `core.py.template` file in this repository contains a Python implementation of all static policy enforcement points (PEPs) from a default `core.re` rulebase.
 
 - This version of the Python Rule Engine Plugin uses the Python 2.7 interpreter.
 
@@ -109,3 +119,65 @@ Aug  8 20:57:43 pid:23802 NOTICE: writeLine: inString = python_printme [bananas]
 Aug  8 20:57:43 pid:23802 NOTICE: writeLine: inString = PYTHON - python_printme() end
 Aug  8 20:57:43 pid:23802 NOTICE: writeLine: inString = PYTHON - acPostProcForPut() end
 ```
+
+- Some python identifiers, such as `global_vars` (a lookup for accessing variables of the form `*var` from the `INPUT` line, if present) and `irods_types` (a module containing common struct types used for communicating with microservices) are automatically imported into the python interpreter that executes `core.py`.
+- Some python identifiers, such as `global_vars` (a lookup for accessing variables of the form `*var` from the `INPUT` line, if present) and `irods_types` (a module containing common struct types used for communicating with microservices) are automatically imported into the python interpreter that loads `core.py`.
+
+# Auxiliary Python modules
+
+Included with the PREP (Python Rule Engine Plugin) are some other modules that provide a solid foundation of utility for writers of Python rule code.  The plugin directly loads only the module `/etc/irods/core.py`, however any import statements in that file are honored if the modules they target are in the interpreter's import path (`sys.path`).  In addition, `rods`  admin may use `irule` to execute Python rules within `.r` files.  By default, `/etc/irods` is included in the import path, meaning that the modules discussed in this section are accessible to all other Python modules and functions (whether or not they are "rules" proper) whether they be internal to `core.py`, or concomitantly or subsequently loaded by the PREP.
+
+## `session_vars.py`
+This module contains a function `get_map` which may be used to extract session variables from the `rei` parameter passed to any rule function. An example follows:
+
+```
+import session_vars
+def get_irods_username (rule_args, callback, rei):
+  username = ''
+  var_map = session_vars.get_map(rei)
+  user_type = rule_args[0] or 'client_user'
+  userrec = var_map.get(user_type,'')
+  if userrec:
+    username = userrec.get('user_name','')
+  rule_args [0] = username
+```
+
+## `genquery.py`
+Two styles of Python iterator are offered by this module to allow a convenient way
+of accessing GenQuery results from within Python rules.  One iterator allows paged
+results of N rows at a time over each iteration (returning between 1 and 256
+rows at a time in the form of a Python list):
+
+```
+  iter = paged_iterator (
+           ["sum(DATA_SIZE)"], "DATA_NAME like 'file_%.dat'",
+           False, # says we want an integer-indexed row, not key-value lookup
+           callback , N_rows_per_page=1
+  )
+  for row in iter:  # ---> one row returned with sum of size of matching data objects
+    writeLine('serverLog',
+      'result = {}'.format( row[0] ))
+```
+
+while the other returns each row result via a Python generator object:
+
+```
+  for dObj in row_iterator("DATA_NAME,DATA_SIZE" , conditions, True, callback):
+      callback.writeLine ("serverLog",
+        "name = {0} ; size = {1}" . format( dObj['DATA_NAME'], dObj['DATA_SIZE'] )
+      )
+```
+
+Whichever function we call to construct the iterator, the first four arguments to the call are the same:
+
+  * ***columns*** - either a string with comma-separated column names, or a list of column names.
+  * ***condition*** is the "select ... where ..." string traditionally used by the general query.
+  * ***row_return_type***  is either `AS_DICT` or `AS_LIST`. These constants are  defined in the genquery module, and specify
+    whether rows returned from the query will be represented by Python `list` or `dict` objects.
+    - `AS_LIST` lets a column value be indexed from each row using its zero-based position (an integer) of
+      the corresponding column name within the *columns* argument.
+    - `AS_DICT` lets column values be indexed directly using the column name itself (a string). Note however, the
+      seemingly higher convenience of this approach is paid for by an increased **per-row** execution overhead.
+  * ***callback*** - duplicated from the callback argument fed into the enclosing Python rule call
+
+For the paged iterator, there is a fifth argument ***N_rows_per_page***, which is hardlimited to the range [1,256].

--- a/genquery.py
+++ b/genquery.py
@@ -1,0 +1,231 @@
+import itertools
+
+__all__ = [
+    "row_iterator",
+    "paged_iterator",
+    "AS_DICT",
+    "AS_LIST",
+]
+
+MAX_SQL_ROWS = 256
+AUTO_FREE_QUERIES = False
+
+class row_return_type (object):
+    def __init__(self): raise NotImplementedError
+
+class AS_DICT (row_return_type): pass
+class AS_LIST (row_return_type): pass
+
+class bad_column_spec (RuntimeError): pass
+class bad_returntype_spec (RuntimeError): pass
+
+def irods_error_NO_ROWS_FOUND (rv):
+    return (False == rv['status'] and abs(rv['code']) == 808000)
+
+# ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# :::::              generator-style query iterator              :::::
+# ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+def row_iterator ( columns,     # comma-separated string, or list, of columns
+                   conditions,  # genquery condition eg. "COLL_NAME not like '%/trash/%'"
+                   row_return,  # AS_DICT or AS_LIST
+                   callback,
+                   auto_free = None
+                   ):  # python callback object from rule argument list
+
+    import irods_types
+
+    if auto_free is None:
+        auto_free_preferred  = AUTO_FREE_QUERIES
+    else:
+        auto_free_preferred  = bool(auto_free)
+
+    if not issubclass(row_return, row_return_type):
+        raise bad_returntype_spec( "row_return parameter should be AS_DICT or AS_LIST" )
+
+    if not isinstance(columns, (list, tuple)):
+        if isinstance(columns, str):
+            columns = list(map(lambda obj: obj.strip(), columns.split(",")))
+        else:
+            raise bad_column_spec ( "Column argument '{!r}' should be column names " \
+                                    "as list or comma separated string".format(columns))
+
+    if len(columns) < 1:
+        raise bad_column_spec( "Must select at least one column for the query" )
+
+    column_indx = list(map(reversed,enumerate(columns)))
+    column_lookup = dict(column_indx)
+
+    ret_val = callback.msiMakeGenQuery(",".join(columns) , conditions , irods_types.GenQueryInp())
+    genQueryInp = ret_val['arguments'][2]
+    ret_val = callback.msiExecGenQuery(genQueryInp , irods_types.GenQueryOut())
+    genQueryOut = ret_val['arguments'][1]
+    continue_index_old = 1
+
+    need_close = False if irods_error_NO_ROWS_FOUND(ret_val) else True
+
+    try:
+
+        while continue_index_old > 0:
+
+            if irods_error_NO_ROWS_FOUND(ret_val):
+                need_close = False
+                break
+
+            for j in range(genQueryOut.rowCnt):
+                row_as_list = [ genQueryOut.sqlResult[i].row(j) for i in range(len(column_indx)) ]
+                if row_return is AS_DICT:
+                    yield { k : row_as_list[v] for k,v in column_lookup.items() }
+                elif row_return is AS_LIST:
+                    yield row_as_list
+
+            continue_index_old = genQueryOut.continueInx
+
+            if continue_index_old > 0 :
+
+                ret_val = callback.msiGetMoreRows(genQueryInp , genQueryOut, 0)
+                genQueryOut = ret_val['arguments'][1]
+
+    finally: # for 1) GeneratorExit (on generator close())
+             # or  2) normal exit
+
+        if need_close and auto_free_preferred:
+            callback.msiCloseGenQuery(genQueryInp, genQueryOut)
+
+# ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# ::: paged iterator returns a list of up to N rows each iteration :::
+# ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+class paged_iterator (object):
+
+    Auto_Free_Queries = AUTO_FREE_QUERIES
+
+    def __init__(self, columns, conditions, row_return, callback,
+                 N_rows_per_page = MAX_SQL_ROWS, auto_free = None
+                 ):
+
+        if auto_free is not None:
+            self.Auto_Free_Queries = bool(auto_free)
+
+        self.callback = callback
+        self.set_rows_per_page ( N_rows_per_page , hard_limit_at_default = True )
+        self.generator =  row_iterator (columns, conditions, row_return, callback, self.Auto_Free_Queries)
+
+    def __iter__(self): return self
+    def __next__(self): return self.next()
+
+    def set_rows_per_page (self, rpp, hard_limit_at_default = False):
+
+        self.rows_per_page = max (1, int(rpp))
+
+        if hard_limit_at_default:
+            self.rows_per_page = min( self.rows_per_page,  MAX_SQL_ROWS )
+
+        return self
+
+    def next_arbitrary_size(self):
+
+        this_page = list(itertools.islice(self.generator, self.rows_per_page))
+        if 0 == len(this_page) : raise StopIteration
+        return this_page
+
+    def next(self):
+
+        if self.rows_per_page > MAX_SQL_ROWS:
+
+            return self.next_arbitrary_size()
+
+        else:
+
+            results = list( range(self.rows_per_page) )
+            j = 0
+
+            try:
+                while j < len(results):
+                    results[j] = next(self.generator)
+                    j += 1
+            except StopIteration:
+                if j == 0: raise
+            except Exception as e:
+                self.callback.writeLine('serverLog',
+                  '*** UNEXPECTED Exception in genquery.py paged iterate [next()]')
+                self.callback.writeLine('serverLog','***   {!r}'.format(e))
+                raise
+
+            # -- truncate list size to fit the generated results
+            del results[j:]
+
+            return results
+
+
+def logPrinter(callback, stream):
+  return lambda logMsg : callback.writeLine( stream, logMsg )
+
+#
+#  The rule code below takes (like_path_rhs , requested_rowcount) as arguments via "rule_args" param
+#
+#    like_path_rhs :     {collection}/{dataname_sql_pattern} eg: '/myZone/home/alice/%'
+#    requested_rowcount : '<integer>' (for #rows-per-page) or '' (use generator)
+#    detailed logging stream : one of [ 'serverLog', 'stdout', 'stderr', '' ]
+
+def test_python_RE_genquery_iterators( rule_args , callback, rei ):
+
+    cond_like_RHS = rule_args[0]
+    coll_name = "/".join(cond_like_RHS.split('/')[:-1])
+    data_obj_name_pattern = cond_like_RHS.split('/')[-1]
+
+    requested_rowcount = str( rule_args[1] )
+
+    if rule_args[2:] and rule_args[2]:
+        logger = logPrinter(callback, rule_args[2])
+    else:
+        logger = lambda logMsg: None
+
+    conditions = "COLL_NAME = '{0}' AND DATA_NAME like '{1}'".format(
+                  coll_name , data_obj_name_pattern )
+    nr = 0
+    n = 0
+
+    last_page = None
+
+    lists_generated  = 0
+    lists_remainder = 0
+
+    if len(requested_rowcount) > 0:
+
+        rows_per_page = int(requested_rowcount)
+
+        logger( "#\n#\n__query: (%d) rows at a time__"%(rows_per_page,) )
+        for page in paged_iterator("DATA_NAME,DATA_SIZE" , conditions, AS_DICT, callback,
+                                                         N_rows_per_page = rows_per_page ):
+            i = 0
+            logger("__new_page_from_query__")
+            for row in page:
+
+                logger( ("n={0},i={1} ; name = {2} ; size = {3}"
+                        ).format(n, i, row['DATA_NAME'], row['DATA_SIZE'] ))
+                n += 1
+                i += 1
+                nr += 1
+
+            lists_generated += 1
+            last_page = page
+
+    else:
+
+        logger( "__gen_mode_return_all_rows_from_query__" )
+
+        for row in row_iterator( "DATA_NAME,DATA_SIZE" , conditions, AS_DICT, callback ):
+
+            logger( ("n = {0} ; name = {1} ; size = {2}"
+                          ).format( n, row['DATA_NAME'], row['DATA_SIZE'] ))
+            n += 1
+            nr += 1
+
+    if lists_generated > 0:
+        lists_remainder = len( last_page )
+
+    rule_args[0] = str( nr ) # -> fetched rows total
+    rule_args[1] = str( lists_generated )
+    rule_args[2] = str( lists_remainder )
+


### PR DESCRIPTION
1 This formalizes  the addition of the genquery.py module into the PREP.
2 The full suite of tests for this module's functionality is not yet complete.
3 Usage examples for the row_iterator and paged_iterator yet to be added to the README.