### PR TITLE
[#21] adjust build config to match irods/irods master at 4.3

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -10,18 +10,16 @@ import irods_python_ci_utilities
 
 
 def install_cmake_and_add_to_front_of_path():
-    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.5.2-0'])
-    os.environ['PATH'] = '/opt/irods-externals/cmake3.5.2-0/bin' + os.pathsep + os.environ['PATH']
+    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.11.4-0'])
+    os.environ['PATH'] = '/opt/irods-externals/cmake3.11.4-0/bin' + os.pathsep + os.environ['PATH']
 
 def get_build_prerequisites_all():
-    return ['irods-externals-clang3.8-0',
-            'irods-externals-cppzmq4.1-0',
-            'irods-externals-libarchive3.1.2-0',
-            'irods-externals-avro1.7.7-0',
-            'irods-externals-clang-runtime3.8-0',
-            'irods-externals-boost1.60.0-0',
+    return [
+            'irods-externals-clang6.0-0',
+            'irods-externals-clang-runtime6.0-0',
+            'irods-externals-boost1.67.0-0', 
             'irods-externals-jansson2.7-0',
-            'irods-externals-zeromq4-14.1.3-0']
+            ]
 
 def get_build_prerequisites_apt():
     return ['make', 'python-dev', 'libssl-dev', 'gcc'] + get_build_prerequisites_all()


### PR DESCRIPTION
Changes to build script,  necessary for the Python Rule Engine to build & test against iRODS master branch
