### PR TITLE
[#65] Manually include pyconfig.h before features.h can be included (master)

### DIFF
--- a/irods_rule_engine_plugin-python.cxx
+++ b/irods_rule_engine_plugin-python.cxx
@@ -1,3 +1,6 @@
+// include this first to fix macro redef warnings
+#include <pyconfig.h>
+
 #include <ctime>
 #include <fstream>
 #include <list>

--- a/irods_types.cpp
+++ b/irods_types.cpp
@@ -1,5 +1,8 @@
 #define BOOST_PYTHON_MAX_ARITY 45
 
+// include this first to fix macro redef warnings
+#include <pyconfig.h>
+
 #define MAKE_IRODS_ERROR_MAP
 #include "rodsErrorTable.h"
 #define MAKE_IRODS_STATE_MAP


### PR DESCRIPTION
This avoids macro-redefined warnings when `pyconfig.h` includes feature test macros.

Addresses #65