### PR TITLE
Irods query on 4 2 stable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
 
 project(irods_rule_engine_plugin-python CXX)
 
+include(GenerateExportHeader)
+set(CMAKE_CXX_VISIBILITY_PRESET default)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 0)
+
 include(${IRODS_TARGETS_PATH})
 
 set(IRODS_PLUGIN_VERSION "${IRODS_VERSION}.${IRODS_PLUGIN_REVISION}")
@@ -90,7 +94,15 @@ set(
       irods_server
       )
 
-  target_compile_definitions(${PLUGIN} PRIVATE ${IRODS_RULE_ENGINE_PYTHON_PLUGIN_COMPILE_DEFINITIONS} ${IRODS_COMPILE_DEFINITIONS})
+  target_compile_definitions(${PLUGIN} PRIVATE ${IRODS_RULE_ENGINE_PYTHON_PLUGIN_COMPILE_DEFINITIONS} ${IRODS_COMPILE_DEFINITIONS}
+                                             RODS_SERVER
+                                             IRODS_QUERY_ENABLE_SERVER_SIDE_API
+                                             RODS_ENABLE_SYSLOG
+                                             IRODS_FILESYSTEM_ENABLE_SERVER_SIDE_API
+                                             IRODS_IO_TRANSPORT_ENABLE_SERVER_SIDE_API
+                                             SPDLOG_FMT_EXTERNAL
+                                             SPDLOG_NO_TLS
+  )
   #target_compile_options(${PLUGIN} PRIVATE -Wno-write-strings)
   set_property(TARGET ${PLUGIN} PROPERTY CXX_STANDARD ${IRODS_CXX_STANDARD})
 

--- a/IRODS_QUERY_DEMO_CORE.py
+++ b/IRODS_QUERY_DEMO_CORE.py
@@ -1,0 +1,188 @@
+import irods_query as _irods_query
+from irods_query import (query_iterator, vector_of_string, query_type)
+import re,os
+from pprint import pprint,pformat
+
+class IrodsQuery(object):
+
+    class Row( object ):
+        def keys(self): return self.columns
+        def as_dict(self): return { k : self[k] for k in self.keys() }
+        def __init__(self,values,columns):
+            self.values = values
+            self.columns = columns
+            self.columns_dict = dict(zip(columns,values))
+        def __iter__(self):
+            return iter(self.values)
+        def __getitem__(self,n):
+            if isinstance(n,int):   return self.values[n]
+            elif isinstance(n,str): return self.columns_dict[n]
+            else:                   raise KeyError
+
+    __attributes = re.split('\s+', 'comm zone_hint query_string auto_fields query_type_ query_limit row_offset bind_args')
+
+    def __init__(self, comm,
+                       query_string,
+                       auto_fields = (),
+                       zone_hint="",
+                       query_limit=0,
+                       row_offset=0,
+                       query_type_ = query_type.SPECIFIC,
+                       bind_args=() ):
+        self.__qi = None
+        for x in self.__attributes:
+            setattr(self,x,locals()[x])
+
+    def __iter__(self):
+        if self.__qi is None:
+            self.__args = vector_of_string()
+            self.__args.assign(self.bind_args)
+            self.__qi = iter( query_iterator( self.comm,
+                                              self.query_string,
+                                              self.__args, "", 0, 0, self.query_type_))
+        return self
+
+    def next(self):
+        try:
+            n = next( self.__qi )
+        except StopIteration as e:
+            self.__qi = None
+            raise
+        else:
+            return self.Row(n, self.auto_fields)
+
+    @property 
+    def args(self): return tuple(self.__args)
+
+def qc2gmain(arg,cbk,rei):
+
+    if arg[:1] == [ '0', ]:
+
+        qGen  = "select USER_GROUP_ID,USER_GROUP_NAME where USER_NAME = 'dan' and USER_GROUP_NAME != 'rodsgroup'" 
+        q_with_fields = IrodsQuery( rei.rsComm, qGen, auto_fields = ('gpid','gpnm'), query_type_ = query_type.GENERAL )
+        for row in q_with_fields:
+            cbk.writeLine('stderr', repr(row.as_dict()))
+
+    elif arg[:1] == [ '1', ]:
+
+        q = IrodsQuery( rei.rsComm, 'select COLL_NAME,DATA_NAME', query_type_ = query_type.GENERAL )
+        for colldata in q:
+            cbk.writeLine('stderr','{0}/{1}'.format(*colldata))
+
+def qc2dmain(arg,cbk,rei):
+    i = IrodsQuery( rei.rsComm, 'listGroupsForUser', auto_fields = ('GrpID','GrpName'), bind_args = ('dan',))
+    for z in i:
+        cbk.writeLine('stderr','id={GrpID}. name={GrpName}.'.format(**z))
+
+def qc2main(arg,cbk,rei):
+    i = IrodsQuery( rei.rsComm, 'listGroupsForUser', bind_args = ('dan',))
+    for x,y in i:
+        cbk.writeLine('stderr','{x},{y}'.format(**locals()))
+
+def qc1main(arg,cbk,rei):
+    i = IrodsQuery( rei.rsComm, 'sq1y1', bind_args = ('dan',))
+    for x, in i:
+        cbk.writeLine('stderr','{x}, '.format(**locals()))
+
+def qcmain(arg,cbk,rei):
+    i = IrodsQuery( rei.rsComm, 'sq2arg', bind_args = ('dan','rodsgroup'))
+    for x,y in i:
+        cbk.writeLine('stderr','{x}, {y}'.format(**locals()))
+
+
+def ACTIVATE_VIRT_ENV(File=None):
+  import sys
+  ctx={'__file__':File}
+  if sys.version_info >= (3,):
+    exec(open(File,'r').read(),ctx)
+  else:
+    execfile(File,ctx)
+
+def fff(*x):
+  ACTIVATE_VIRT_ENV('/home/daniel/py2/bin/activate_this.py')
+  import h5py
+def ggg(*x):
+  import h5py
+
+'''
+sq1y1
+select group_user_id from R_USER_GROUP ug inner join R_USER_MAIN u on ug.group_user_id = u.user_id where user_type_name = 'rodsgroup' and ug.user_id = (select user_id from R_USER_MAIN where user_name = ? and user_type_name != 'rodsgroup')
+----
+sq1
+select group_user_id, user_name from R_USER_GROUP ug inner join R_USER_MAIN u on ug.group_user_id = u.user_id where user_type_name = 'rodsgroup' and ug.user_id = (select user_id from R_USER_MAIN where user_name = 'dan' and user_type_name != 'rodsgroup')
+----
+sq2arg
+select group_user_id, user_name from R_USER_GROUP ug inner join R_USER_MAIN u on ug.group_user_id = u.user_id where user_type_name = 'rodsgroup' and ug.user_id = (select user_id from R_USER_MAIN where user_name = ? and user_type_name != ?)
+'''
+
+
+def qmain(arg,cbk,rei):
+    args =  vector_of_string();
+    args.assign( ['dan','rodsgroup'] ) 
+    qit = query_iterator( rei.rsComm, 
+                          'sq2arg', 
+                          args, "", 0, 0, _irods_query.query_type.SPECIFIC )
+    qi = iter(qit)
+    try:
+      while True:
+        y = next(qi)
+        len(y)
+        cbk.writeLine('stderr','id = {y[0]} ; name = {y[1]}'.format(**locals()) )
+    except StopIteration:
+      print('--stopped--')
+
+def qqmain(arg,cbk,rei):
+    q_general  = "select USER_GROUP_ID, USER_GROUP_NAME where USER_NAME = 'dan' and USER_GROUP_NAME != 'rodsgroup'" 
+    q_specific = "select group_user_id, user_name from R_USER_GROUP ug inner join R_USER_MAIN u on ug.group_user_id" \
+                 " = u.user_id where user_type_name = 'rodsgroup' and ug.user_id = (select "                         \
+                 "user_id from R_USER_MAIN where user_name = ? and user_type_name != 'rodsgroup')"
+    args =  vector_of_string();
+    empty =  vector_of_string();
+    args.assign( ['dan','rodsgroup'] ) 
+    n_arg =  arg[0]
+    if n_arg == "2":
+      # -- general query
+      qi = query_iterator( rei.rsComm, q_general )
+    elif n_arg == "5":
+      # -- specific but no args passed
+      # test with: iadmin asq "<sql>" sq1 where sql like above but "?" replaced by eg "'username'"
+      qi = query_iterator( rei.rsComm, "sq1", 0, 0, _irods_query.query_type.SPECIFIC )
+    elif n_arg == "7":
+      # test with: iadmin asq "<sql>" sq2arg where sql like above but "'rodsadmin'" replaced by "?"
+      qi = query_iterator( rei.rsComm, 
+                           'sq2arg', 
+                           args, "", 0, 0, _irods_query.query_type.SPECIFIC )
+    elif n_arg == "7g":
+      qi = query_iterator( rei.rsComm, 
+                           'select DATA_ID', 
+                           empty, "", 0, 0, _irods_query.query_type.GENERAL )
+      for _ in qi: 
+        cbk.writeLine('stderr',(_)[0])
+      return
+    for y in qi:
+      cbk.writeLine('stderr','id = {y[0]} ; name = {y[1]}'.format(**locals()) )
+
+'''
+def eemain(arg,cbk,rei):
+    x = _irods_query.fnee( _irods_query.query_type.SPECIFIC )
+    x = str(x) 
+    cbk.writeLine('stdout','ty = '+x)
+def emain(arg,cbk,rei):
+    x = _irods_query.fne( _irods_query.mychoice.TWO )   
+    x = str(x) #  str(dir(irods_query)) #. query_iterator
+               #   x=""
+    cbk.writeLine('stdout','neg int from enum = '+x)
+
+def mmain(arg,cbk,rei):
+    args =  vector_of_string()
+    args.assign( ["-1","55"] )
+
+    y =  str(dir(irods_query)) #. query_iterator
+    cbk.writeLine('stdout',y)
+
+    pargs = const_ptr(args)
+    x = fnv(pargs);
+    x = str(x) #  str(dir(irods_query)) #. query_iterator
+               #   x=""
+    cbk.writeLine('stdout',x)
+'''

--- a/IRODS_QUERY_DEMO_CORE.py
+++ b/IRODS_QUERY_DEMO_CORE.py
@@ -1,58 +1,10 @@
 import irods_query as _irods_query
 from irods_query import (query_iterator, vector_of_string, query_type)
+from irods_query_wrapper import * # --> IrodsQuery
 import re,os
 from pprint import pprint,pformat
 
-class IrodsQuery(object):
-
-    class Row( object ):
-        def keys(self): return self.columns
-        def as_dict(self): return { k : self[k] for k in self.keys() }
-        def __init__(self,values,columns):
-            self.values = values
-            self.columns = columns
-            self.columns_dict = dict(zip(columns,values))
-        def __iter__(self):
-            return iter(self.values)
-        def __getitem__(self,n):
-            if isinstance(n,int):   return self.values[n]
-            elif isinstance(n,str): return self.columns_dict[n]
-            else:                   raise KeyError
-
-    __attributes = re.split('\s+', 'comm zone_hint query_string auto_fields query_type_ query_limit row_offset bind_args')
-
-    def __init__(self, comm,
-                       query_string,
-                       auto_fields = (),
-                       zone_hint="",
-                       query_limit=0,
-                       row_offset=0,
-                       query_type_ = query_type.SPECIFIC,
-                       bind_args=() ):
-        self.__qi = None
-        for x in self.__attributes:
-            setattr(self,x,locals()[x])
-
-    def __iter__(self):
-        if self.__qi is None:
-            self.__args = vector_of_string()
-            self.__args.assign(self.bind_args)
-            self.__qi = iter( query_iterator( self.comm,
-                                              self.query_string,
-                                              self.__args, "", 0, 0, self.query_type_))
-        return self
-
-    def next(self):
-        try:
-            n = next( self.__qi )
-        except StopIteration as e:
-            self.__qi = None
-            raise
-        else:
-            return self.Row(n, self.auto_fields)
-
-    @property 
-    def args(self): return tuple(self.__args)
+#__ demo / test __
 
 def qc2gmain(arg,cbk,rei):
 
@@ -161,28 +113,3 @@ def qqmain(arg,cbk,rei):
       return
     for y in qi:
       cbk.writeLine('stderr','id = {y[0]} ; name = {y[1]}'.format(**locals()) )
-
-'''
-def eemain(arg,cbk,rei):
-    x = _irods_query.fnee( _irods_query.query_type.SPECIFIC )
-    x = str(x) 
-    cbk.writeLine('stdout','ty = '+x)
-def emain(arg,cbk,rei):
-    x = _irods_query.fne( _irods_query.mychoice.TWO )   
-    x = str(x) #  str(dir(irods_query)) #. query_iterator
-               #   x=""
-    cbk.writeLine('stdout','neg int from enum = '+x)
-
-def mmain(arg,cbk,rei):
-    args =  vector_of_string()
-    args.assign( ["-1","55"] )
-
-    y =  str(dir(irods_query)) #. query_iterator
-    cbk.writeLine('stdout',y)
-
-    pargs = const_ptr(args)
-    x = fnv(pargs);
-    x = str(x) #  str(dir(irods_query)) #. query_iterator
-               #   x=""
-    cbk.writeLine('stdout',x)
-'''

--- a/irods_query_wrapper.py
+++ b/irods_query_wrapper.py
@@ -1,0 +1,74 @@
+import irods_query as _irods_query
+import re
+
+class IrodsQuery(object):
+
+    class Row( object ):
+        def keys(self): return self.columns
+        def as_dict(self): return { k : self[k] for k in self.keys() }
+        def __init__(self,values,columns):
+            self.values = values
+            self.columns = columns
+            self.columns_dict = dict(zip(columns,values))
+        def __iter__(self):
+            return iter(self.values)
+        def __getitem__(self,n):
+            if isinstance(n,int):   return self.values[n]
+            elif isinstance(n,str): return self.columns_dict[n]
+            else:                   raise KeyError
+
+    from irods_query import (query_iterator, vector_of_string)
+
+    GENERAL  = _irods_query.query_type.GENERAL
+    SPECIFIC = _irods_query.query_type.SPECIFIC
+
+    __attributes = re.split('\s+', 'comm zone_hint query_string auto_fields query_type query_limit row_offset bind_args')
+
+    def __init__(self, comm,             # rei.rsComm from rule parameter
+                       query_string,     # "select FIELD1,FIELD2 from ... where ... "
+                       auto_fields = (), # Up to n dictionary-like keys to correspond with FIELD(0..n-1)
+                       zone_hint = "",
+                       query_limit = 0,
+                       row_offset = 0,
+                       query_type = _irods_query.query_type.GENERAL, # IrodsQuery.GENERAL
+                       bind_args = () ): # args for ? ; only if query_type is SPECIFIC
+        self.__qi = None
+        for x in self.__attributes:
+            setattr(self,x,locals()[x])
+
+    def __iter__(self):
+        if self.__qi is None:
+            self.__args = self.vector_of_string()
+            self.__args.assign(self.bind_args)
+            self.__qi = iter( self.query_iterator( self.comm,
+                                                   self.query_string,
+                                                   self.__args, "", 0, 0, self.query_type))
+        return self
+
+    def next(self):
+        try:
+            n = next( self.__qi )
+        except StopIteration as e:
+            self.__qi = None
+            raise
+        else:
+            return self.Row(n, self.auto_fields)
+
+    @property 
+    def args(self): return tuple(self.__args)
+
+# -- usage in core.py --
+#
+# from irods_query_wrapper import ( IrodsQuery )
+# 
+# def gen_q(arg,cbk,rei):
+#     for (i,d,c) in IrodsQuery (rei.rsComm, "select DATA_ID,DATA_NAME,COLL_NAME"):
+#         cbk.writeLine ("stdout", "id = %s : %s/%s" % (i,c,d) )
+# 
+# def spec_q(arg,cbk,rei):
+#     for row in IrodsQuery( rei.rsComm, "listGroupsForUser",
+#                            bind_args=('dan',),
+#                            auto_fields=('grp_id','grp_name'), 
+#                            query_type = IrodsQuery.SPECIFIC
+#                          ):
+#         cbk.writeLine ("stdout", "Group ID {grp_id} NAME {grp_name}".format(**row))

--- a/query_python_demo.sh
+++ b/query_python_demo.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+case $1 in
+  0) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qc2gmain('1')" null ruleExecOut ;;
+  1) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qc2gmain('0')" null ruleExecOut ;;
+  2) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qc2dmain()" null ruleExecOut ;;
+  3) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qc1main()" null ruleExecOut ;;
+  4) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qc2main()" null ruleExecOut ;;
+  5) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qcmain()" null ruleExecOut ;;
+  6) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qmain()" null ruleExecOut ;;
+  7) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qqmain('2')" null ruleExecOut ;;
+  8) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qqmain('5')" null ruleExecOut ;;
+  9) irule -r irods_rule_engine_plugin-irods_rule_language-instance "qqmain('7')" null ruleExecOut ;;
+  *) exit 123;;
+esac


### PR DESCRIPTION
A new module **irods_query** which 
  - wraps irods::query C++ iterator class using boost-python
  -  provides general and specific query from Python rules.
  - gives access to bind args (?) in the SQL for specific query

A supplementary module, irods_query_wrapper.py , offers  the IrodsQuery , which is a higher level abstraction (a Python iterator class). It is used in this manner:
```
def my_rule( rule_args, callback, rei):
  for row in IrodsQuery( rei.rsComm, "select <row_names>  [from <table_names>] where [condition]" , 
                                    query_type = IrodsQuery.[GENERAL|SPECIFIC], [ other options as required... ] ):
      # process each `row' 
```

---
Tests still need to be written.