### PR TITLE
[#74] Use 'default' in core.py.template for acSetNumThreads (4-2-stable)

### DIFF
--- a/core.py.template
+++ b/core.py.template
@@ -174,7 +174,7 @@ def acPostProcForRepl(rule_args, callback, rei):
     pass
 
 def acSetNumThreads(rule_args, callback, rei):
-    callback.msiSetNumThreads('default', '64', 'default')
+    callback.msiSetNumThreads('default', 'default', 'default')
 
 def acDataDeletePolicy(rule_args, callback, rei):
     pass


### PR DESCRIPTION
CI tests passed except for one test which is being addressed in irods/irods#5667