### PR TITLE
[#74] Use 'default' in core.py.template for acSetNumThreads (master)

### DIFF
--- a/core.py.template
+++ b/core.py.template
@@ -174,7 +174,7 @@ def acPostProcForRepl(rule_args, callback, rei):
     pass
 
 def acSetNumThreads(rule_args, callback, rei):
-    callback.msiSetNumThreads('default', '64', 'default')
+    callback.msiSetNumThreads('default', 'default', 'default')
 
 def acDataDeletePolicy(rule_args, callback, rei):
     pass


### PR DESCRIPTION
cherry-picked in changes made for #75 

CI tests will run later