### PR TITLE
[#86] Add missing static PEP to core.py.template (4-2-stable)

### DIFF
--- a/core.py.template
+++ b/core.py.template
@@ -325,3 +325,6 @@ def acPreProcForServerPortal(rule_args, callback, rei):
 
 def acPostProcForServerPortal(rule_args, callback, rei):
     pass
+
+def acPostProcForDataCopyReceived(rule_args, callback, rei):
+    pass


### PR DESCRIPTION
The equivalent in core.re.template is the following:

acPostProcForDataCopyReceived(*leaf_resource) {}

Errors are being generated in the logs as tests are running.