### PR TITLE
[#86] Add missing static PEP to core.py.template (master)

### DIFF
--- a/core.py.template
+++ b/core.py.template
@@ -325,3 +325,6 @@ def acPreProcForServerPortal(rule_args, callback, rei):
 
 def acPostProcForServerPortal(rule_args, callback, rei):
     pass
+
+def acPostProcForDataCopyReceived(rule_args, callback, rei):
+    pass


### PR DESCRIPTION
The equivalent in core.re.template is the following:

acPostProcForDataCopyReceived(*leaf_resource) {}

This change makes the core.py.template align more with core.re.template.

---

cherry-picked from work done for #85