### PR TITLE
Add build_directory option to build hook (4-2-stable)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -60,11 +60,11 @@ def copy_output_packages(build_directory, output_root_directory):
         irods_python_ci_utilities.append_os_specific_directory(output_root_directory),
         lambda s:s.endswith(irods_python_ci_utilities.get_package_suffix()))
 
-def main(output_root_directory, irods_packages_root_directory, externals_directory):
+def main(build_directory, output_root_directory, irods_packages_root_directory, externals_directory):
     install_building_dependencies(externals_directory)
     if irods_packages_root_directory:
         irods_python_ci_utilities.install_irods_dev_and_runtime_packages(irods_packages_root_directory)
-    build_directory = tempfile.mkdtemp(prefix='irods_python_rule_engine_plugin_build_directory')
+    build_directory = os.path.abspath(build_directory or tempfile.mkdtemp(prefix='irods_python_rule_engine_plugin_build_directory'))
     irods_python_ci_utilities.subprocess_get_output(['cmake', os.path.dirname(os.path.realpath(__file__))], check_rc=True, cwd=build_directory)
     irods_python_ci_utilities.subprocess_get_output(['make', '-j', str(multiprocessing.cpu_count()), 'package'], check_rc=True, cwd=build_directory)
     if output_root_directory:
@@ -72,9 +72,13 @@ def main(output_root_directory, irods_packages_root_directory, externals_directo
 
 if __name__ == '__main__':
     parser = optparse.OptionParser()
+    parser.add_option('--build_directory')
     parser.add_option('--output_root_directory')
     parser.add_option('--irods_packages_root_directory')
     parser.add_option('--externals_packages_directory')
     options, _ = parser.parse_args()
 
-    main(options.output_root_directory, options.irods_packages_root_directory, options.externals_packages_directory)
+    main(options.build_directory,
+         options.output_root_directory,
+         options.irods_packages_root_directory,
+         options.externals_packages_directory)


### PR DESCRIPTION
The user of the build hook now has more control over where build
artifacts are placed. If no build directory is provided through the
option, the historic, temporary directory behavior is used.

---

We should probably add this option to all of the existing build hooks should we decide to proceed. I have found it to be very useful for increased build flexibility with automated systems.
