### PR TITLE
[irods/irods#4649] Clear returned microservice parameters (master)

### DIFF
--- a/irods_rule_engine_plugin-python.cxx
+++ b/irods_rule_engine_plugin-python.cxx
@@ -285,6 +285,7 @@ namespace
                 }
                 else {
                     ret_list.append(object_from_msParam(msParams.front()));
+                    clearMsParam(&msParams.front(), 1);
                     msParams.pop_front();
                 }
 


### PR DESCRIPTION
As the return list is cleared after executing a rule, the microservice
parameters that are returned need to be properly free'd. Popping them
from the list of parameters causes leaking because the inOutStruct and
other members are not properly handled.

cherry-picked from work done for #90