### PR TITLE
BytesBuf set_buffer( ) method for arbitrary binary read/write on data objects [main]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ project(irods_rule_engine_plugin-python
   VERSION "${IRODS_PLUGIN_VERSION}"
   LANGUAGES CXX)
 
+find_package(Threads REQUIRED)
+
 set(CMAKE_SKIP_BUILD_RPATH OFF)
 set(CMAKE_SKIP_INSTALL_RPATH OFF)
 set(CMAKE_SKIP_RPATH OFF)
@@ -37,7 +39,7 @@ if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 if (NOT IRODS_PYTHON_VERSION)
-  set(IRODS_PYTHON_VERSION "2" CACHE STRING "The version of python to link against" FORCE)
+  set(IRODS_PYTHON_VERSION "3" CACHE STRING "The version of python to link against" FORCE)
   message(STATUS "Setting unspecified IRODS_PYTHON_VERSION to '${IRODS_PYTHON_VERSION}'. This is the correct setting for normal builds.")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,40 @@ def get_irods_username (rule_args, callback, rei):
   rule_args [0] = username
 ```
 
+## Special methods
+
+Some iRODS objects used with rules and microservices have been given utility methods.
+
+An example is the map() method of a `PluginContext` PEP argument:
+```
+    def pep_resource_resolve_hierarchy_pre(rule_args, callback, rei):
+        import pprint
+        pprint.pprint(rule_args[1].map().items())
+```
+
+In version 4.2.11.2 of the Python plugin, `BytesBuf` has methods to set and access byte content.
+These can be used to achieve true binary reads and writes, to and from data objects.
+
+For example:
+```
+    def my_rule(args, callback, rei):
+        buf = irods_types.BytesBuf()
+        buf.set_buffer( os.urandom(256) )
+        callback.msiDataObjectWrite( descriptor, buf, 0)  #-- Write the buffer.
+        # ...
+        buf.clear_buffer()
+```
+or:
+```
+    # ...
+    retv = callback.msiDataObjectRead( descriptor, "256", irods_types.BytesBuf())
+    returnbuf = retv['arguments'][2]
+    out = returnbuf.get_bytes()         #--  Returns list of integer octets.
+    start_byte = returnbuf.get_byte(0)  #--  Returns first octet
+```
+
+
+
 ## `genquery.py`
 
 This module offers writers of Python rules a convenient facility for querying and iterating over objects in the iRODS object catalog (ICAT).

--- a/python_rules/rulemsiDataObjWrite_binary.r
+++ b/python_rules/rulemsiDataObjWrite_binary.r
@@ -1,0 +1,59 @@
+def main(rule_args, callback, rei):
+    return data_obj_binary_write_test__104(callback)
+
+class error_tracker:
+
+    def __init__(self):
+        self.code = 0
+
+    def assert_(self,
+                nonzero_value,
+                bool_lambda = lambda:False):   # The lambda is for lazy evaluation.
+                                               # `nonzero_value' should be negative and not be
+                                               # the same in absolute value as any valid errno code.
+        if self.code == 0:
+            self.code = (0 if bool_lambda() else nonzero_value)
+
+def data_obj_binary_write_test__104(callback):
+
+    binary_bytes = irods_types.BytesBuf()
+
+    buffer = bytearray((256 + 127 - i) % 256 for i in range(256))  # Create a list of [127,126,...,0,255,254,...,128]
+    buffer_length = len(buffer)
+    dest_file = '/tempZone/home/rods/test_buffer__104'
+
+    binary_bytes.set_buffer(buffer)
+
+    err = error_tracker()
+    try:
+        binary_bytes.get_byte(10240)
+    except IndexError:
+        pass               # This error is the expected result of get_byte with too large an index.
+    else:
+        err.assert_(-997)  # Error because an exception should have been thrown by the out-of-range access.
+
+    ret_val = callback.msiDataObjOpen(
+       ('objPath={}++++openFlags=O_RDWR''O_CREAT''O_TRUNC').format(dest_file)
+       , 0)
+    f = ret_val['arguments'][1]
+
+    callback.msiDataObjWrite(f, binary_bytes, buffer_length)
+    binary_bytes.clear_buffer()
+
+    callback.msiDataObjLseek(f, "0", "SEEK_SET", 0)
+
+    ret_val = callback.msiDataObjRead(f, str(16+buffer_length), irods_types.BytesBuf())
+    read_buffer = ret_val['arguments'][2]
+
+    err.assert_(-999, lambda: list(buffer) == read_buffer.get_bytes())
+    err.assert_(-998, lambda: buffer_length == read_buffer.len)
+
+    read_buffer.clear_buffer()
+
+    callback.msiDataObjClose(f, 0)
+    callback.msiDataObjUnlink("objPath="+dest_file,0)
+
+    return err.code
+
+INPUT null
+OUTPUT ruleExecOut


### PR DESCRIPTION
Includes:
- cherry-pick of https://github.com/irods/irods_rule_engine_plugin_python/pull/106
- fix for cmake allowing Python rule plugin's `main` branch to build.