### PR TITLE
[irods/irods#6437] Add support for new platforms (main)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -38,13 +38,15 @@ def install_os_specific_dependencies_apt():
     irods_python_ci_utilities.install_os_packages(['make', 'python3-dev', 'libssl-dev', 'gcc'])
 
 def install_os_specific_dependencies_yum():
-    irods_python_ci_utilities.install_os_packages(['python3-devel', 'openssl-devel'])
+    irods_python_ci_utilities.install_os_packages(['make', 'gcc', 'python3-devel', 'openssl-devel'])
 
 def install_os_specific_dependencies():
     dispatch_map = {
         'Ubuntu': install_os_specific_dependencies_apt,
+        'Debian gnu_linux': install_os_specific_dependencies_apt,
         'Centos': install_os_specific_dependencies_yum,
         'Centos linux': install_os_specific_dependencies_yum,
+        'Almalinux': install_os_specific_dependencies_yum
     }
     try:
         return dispatch_map[irods_python_ci_utilities.get_distribution()]()


### PR DESCRIPTION
Confirmed things build for the three platforms and installed on almalinux:8, where tests are now running. debian:11 to follow shortly.