### PR TITLE
[#138] Fix msiDataObjPhymv test rule (4-2-stable)

### DIFF
--- a/python_rules/rulemsiDataObjPhymv.r
+++ b/python_rules/rulemsiDataObjPhymv.r
@@ -8,5 +8,5 @@ def main(rule_args, callback, rei):
 
     callback.writeLine('stdout', 'Replica number ' + replica_number + 'of file ' + source_file + ' is moved from resource ' + source_resource + ' to resource ' + dest_resource)
 
-INPUT *SourceFile="/tempZone/home/rods/forphymv/phymvfile", *DestResource="testallrulesResc", *SourceResource="demoResc", *ReplicaNumber="0"
+INPUT *SourceFile="/tempZone/home/rods/forphymv/phymvfile", *DestResource="testallrulesResc", *SourceResource="demoResc", *ReplicaNumber="null"
 OUTPUT ruleExecOut


### PR DESCRIPTION
Addresses #138 

main branch has this change already. See #114 

Confirmed that this test now passes for 4-2-stable.