### PR TITLE
[#158] array_ref.hpp: add missing <vector> include

### DIFF
--- a/include/irods/private/re/python/types/array_ref.hpp
+++ b/include/irods/private/re/python/types/array_ref.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <iterator>
 #include <stdexcept>
+#include <vector>
 
 template <typename T, bool NullTerminated = false>
 class array_ref;


### PR DESCRIPTION
This fixes building against libstdc++