### PR TITLE
[#183] better handling of rule INPUT and OUTPUT variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ Aug  8 20:57:43 pid:23802 NOTICE: writeLine: inString = PYTHON - acPostProcForPu
 
 # Python globals and built-in modules
 These built-in objects are set up at plugin initialization time and available in the python interpreter that loads `core.py` or, as the case may be, the Python rule file:
-   - `global_vars` - a dictionary for accessing variables of the form `*var` from the `INPUT` line, if present.
+   - `irods_rule_vars` - a dictionary for accessing variables of the form `*var` from the `INPUT` line, if present.
    - `irods_types` - a module containing common struct types used for communicating with microservices.
    - `irods_errors` - a module mapping well-known iRODS error names to their corresponding integer values.
+   - `global_vars` - deprecated alias for `irods_rule_vars`; only available in some contexts. Will be removed in a future release.
    
 By using the `irods_errors` built-in, policy may indicate how the framework is to continue through the use of a symbolic name, rather than a cryptic number reference:
 ```
@@ -165,7 +166,7 @@ def testRule(rule_args, callback, rei):
 and a rule script file (named `call_testRule.r`) which calls `testRule` with a data path argument:
 ```
 def main(_,callback,rei):
-  data_path = global_vars[ '*dataPath' ][1:-1]
+  data_path = irods_rule_vars[ '*dataPath' ][1:-1]
   retval = callback.testRule( data_path )
   callback.writeLine( "stdout", retval['arguments'][0])
 INPUT *dataPath=""

--- a/python_rules/rulegenerateBagIt.r
+++ b/python_rules/rulegenerateBagIt.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    bagIt_data = global_vars['*BAGITDATA'][1:-1]
-    new_bagIt_root = global_vars['*NEWBAGITROOT'][1:-1]
+    bagIt_data = irods_rule_vars['*BAGITDATA'][1:-1]
+    new_bagIt_root = irods_rule_vars['*NEWBAGITROOT'][1:-1]
 
     print_size = 0
     print_unit = ''

--- a/python_rules/rulemsiAddConditionToGenQuery.r
+++ b/python_rules/rulemsiAddConditionToGenQuery.r
@@ -1,8 +1,8 @@
 def main(rule_args, callback, rei):
-    select = global_vars['*Select'][1:-1]
-    attribute = global_vars['*Attribute'][1:-1]
-    operator = global_vars['*Operator'][1:-1]
-    value = global_vars['*Value'][1:-1]
+    select = irods_rule_vars['*Select'][1:-1]
+    attribute = irods_rule_vars['*Attribute'][1:-1]
+    operator = irods_rule_vars['*Operator'][1:-1]
+    value = irods_rule_vars['*Value'][1:-1]
 
     ret_val = {}
 

--- a/python_rules/rulemsiAddKeyValToMspStr.r
+++ b/python_rules/rulemsiAddKeyValToMspStr.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    attr_name = global_vars['*AttrName'][1:-1]
-    attr_value = global_vars['*AttrValue'][1:-1]
+    attr_name = irods_rule_vars['*AttrName'][1:-1]
+    attr_value = irods_rule_vars['*AttrValue'][1:-1]
 
     out_str = '='.join([attr_name, attr_value])
 

--- a/python_rules/rulemsiAddSelectFieldToGenQuery.r
+++ b/python_rules/rulemsiAddSelectFieldToGenQuery.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    select = global_vars['*Select'][1:-1]
-    select_add = global_vars['*SelectAdd'][1:-1]
-    fcn = global_vars['*Function'][1:-1]
+    select = irods_rule_vars['*Select'][1:-1]
+    select_add = irods_rule_vars['*SelectAdd'][1:-1]
+    fcn = irods_rule_vars['*Function'][1:-1]
 
     # Initial select is on COLL_NAME
     ret_val = callback.msiMakeGenQuery(select, "COLL_NAME like '/tempZone/home/rods/%%'", irods_types.GenQueryInp())

--- a/python_rules/rulemsiCheckAccess.r
+++ b/python_rules/rulemsiCheckAccess.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    path = global_vars['*Path'][1:-1]
-    acl = global_vars['*Acl'][1:-1]
+    path = irods_rule_vars['*Path'][1:-1]
+    acl = irods_rule_vars['*Acl'][1:-1]
 
     ret_val = callback.msiCheckAccess(path, acl, 0)
     result = ret_val['arguments'][2]

--- a/python_rules/rulemsiCollCreate.r
+++ b/python_rules/rulemsiCollCreate.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    path = global_vars['*Path'][1:-1]
+    path = irods_rule_vars['*Path'][1:-1]
 
     callback.msiCollCreate(path, '0', 0)
 

--- a/python_rules/rulemsiCollRsync.r
+++ b/python_rules/rulemsiCollRsync.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    src_coll = global_vars['*srcColl'][1:-1]
-    dest_coll = global_vars['*destColl'][1:-1]
-    resource = global_vars['*Resource'][1:-1]
+    src_coll = irods_rule_vars['*srcColl'][1:-1]
+    dest_coll = irods_rule_vars['*destColl'][1:-1]
+    resource = irods_rule_vars['*Resource'][1:-1]
 
     callback.msiCollRsync(src_coll, dest_coll, resource, 'IRODS_TO_IRODS', 0)
 

--- a/python_rules/rulemsiDataObjChksum.r
+++ b/python_rules/rulemsiDataObjChksum.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    data_object = global_vars['*dataObject'][1:-1]
-    flags = global_vars['*Flags'][1:-1]
+    data_object = irods_rule_vars['*dataObject'][1:-1]
+    flags = irods_rule_vars['*Flags'][1:-1]
 
     import os
     (coll, file) = os.path.split(data_object)

--- a/python_rules/rulemsiDataObjClose.r
+++ b/python_rules/rulemsiDataObjClose.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    resc = global_vars['*Resc'][1:-1]
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
+    resc = irods_rule_vars['*Resc'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
 
     ret_val = callback.msiDataObjCreate(obj, oflags, 0)
     file_desc = ret_val['arguments'][2]

--- a/python_rules/rulemsiDataObjCopy.r
+++ b/python_rules/rulemsiDataObjCopy.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    dest_file = global_vars['*DestFile'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    dest_file = irods_rule_vars['*DestFile'][1:-1]
 
     callback.msiDataObjCopy(source_file, dest_file, 'forceFlag=', 0)
     callback.writeLine('stdout', 'File ' + source_file + ' copied to ' + dest_file)

--- a/python_rules/rulemsiDataObjCreate.r
+++ b/python_rules/rulemsiDataObjCreate.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    resc = global_vars['*Resc'][1:-1]
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
+    resc = irods_rule_vars['*Resc'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
 
     ret_val = callback.msiDataObjCreate(obj, oflags, 0)
     file_desc = ret_val['arguments'][2]

--- a/python_rules/rulemsiDataObjGet.r
+++ b/python_rules/rulemsiDataObjGet.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
 
     import os
     (coll, file) = os.path.split(source_file)

--- a/python_rules/rulemsiDataObjLseek.r
+++ b/python_rules/rulemsiDataObjLseek.r
@@ -1,11 +1,11 @@
 def main(rule_args, callback, rei):
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
-    obj_b = global_vars['*ObjB'][1:-1]
-    oflags_b = global_vars['*OFlagsB'][1:-1]
-    offset = global_vars['*Offset'][1:-1]
-    loc = global_vars['*Loc'][1:-1]
-    length = global_vars['*Len'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
+    obj_b = irods_rule_vars['*ObjB'][1:-1]
+    oflags_b = irods_rule_vars['*OFlagsB'][1:-1]
+    offset = irods_rule_vars['*Offset'][1:-1]
+    loc = irods_rule_vars['*Loc'][1:-1]
+    length = irods_rule_vars['*Len'][1:-1]
 
     ret_val = callback.msiDataObjOpen(oflags, 0)
     file_desc = ret_val['arguments'][1]

--- a/python_rules/rulemsiDataObjOpen.r
+++ b/python_rules/rulemsiDataObjOpen.r
@@ -1,11 +1,11 @@
 def main(rule_args, callback, rei):
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
-    obj_b = global_vars['*ObjB'][1:-1]
-    oflags_b = global_vars['*OFlagsB'][1:-1]
-    offset = global_vars['*Offset'][1:-1]
-    loc = global_vars['*Loc'][1:-1]
-    length = global_vars['*Len'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
+    obj_b = irods_rule_vars['*ObjB'][1:-1]
+    oflags_b = irods_rule_vars['*OFlagsB'][1:-1]
+    offset = irods_rule_vars['*Offset'][1:-1]
+    loc = irods_rule_vars['*Loc'][1:-1]
+    length = irods_rule_vars['*Len'][1:-1]
 
     ret_val = callback.msiDataObjOpen(oflags, 0)
     file_desc = ret_val['arguments'][1]

--- a/python_rules/rulemsiDataObjPhymv.r
+++ b/python_rules/rulemsiDataObjPhymv.r
@@ -1,8 +1,8 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    source_resource = global_vars['*SourceResource'][1:-1]
-    dest_resource = global_vars['*DestResource'][1:-1]
-    replica_number = global_vars['*ReplicaNumber'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    source_resource = irods_rule_vars['*SourceResource'][1:-1]
+    dest_resource = irods_rule_vars['*DestResource'][1:-1]
+    replica_number = irods_rule_vars['*ReplicaNumber'][1:-1]
 
     callback.msiDataObjPhymv(source_file, dest_resource, source_resource, replica_number, 'null', 0)
 

--- a/python_rules/rulemsiDataObjPut.r
+++ b/python_rules/rulemsiDataObjPut.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    dest_file = global_vars['*DestFile'][1:-1]
-    dest_resource = global_vars['*DestResource'][1:-1]
-    local_file = global_vars['*LocalFile'][1:-1]
+    dest_file = irods_rule_vars['*DestFile'][1:-1]
+    dest_resource = irods_rule_vars['*DestResource'][1:-1]
+    local_file = irods_rule_vars['*LocalFile'][1:-1]
 
     callback.msiDataObjPut(dest_file, dest_resource, 'localPath=' + local_file + '++++forceFlag=', 0)
 

--- a/python_rules/rulemsiDataObjRead.r
+++ b/python_rules/rulemsiDataObjRead.r
@@ -1,11 +1,11 @@
 def main(rule_args, callback, rei):
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
-    obj_b = global_vars['*ObjB'][1:-1]
-    oflags_b = global_vars['*OFlagsB'][1:-1]
-    offset = global_vars['*Offset'][1:-1]
-    loc = global_vars['*Loc'][1:-1]
-    length = global_vars['*Len'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
+    obj_b = irods_rule_vars['*ObjB'][1:-1]
+    oflags_b = irods_rule_vars['*OFlagsB'][1:-1]
+    offset = irods_rule_vars['*Offset'][1:-1]
+    loc = irods_rule_vars['*Loc'][1:-1]
+    length = irods_rule_vars['*Len'][1:-1]
 
     ret_val = callback.msiDataObjOpen(oflags, 0)
     file_desc = ret_val['arguments'][1]

--- a/python_rules/rulemsiDataObjRename.r
+++ b/python_rules/rulemsiDataObjRename.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    new_file_path = global_vars['*NewFilePath'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    new_file_path = irods_rule_vars['*NewFilePath'][1:-1]
 
     callback.msiDataObjRename(source_file, new_file_path, '0', 0)
 

--- a/python_rules/rulemsiDataObjRepl.r
+++ b/python_rules/rulemsiDataObjRepl.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    resource = global_vars['*Resource'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    resource = irods_rule_vars['*Resource'][1:-1]
 
     callback.msiDataObjRepl(source_file, 'destRescName=' + resource, 0)
 

--- a/python_rules/rulemsiDataObjRsync.r
+++ b/python_rules/rulemsiDataObjRsync.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    source_obj = global_vars['*sourceObj'][1:-1]
-    dest_resc = global_vars['*destResc'][1:-1]
-    dest_obj = global_vars['*destObj'][1:-1]
+    source_obj = irods_rule_vars['*sourceObj'][1:-1]
+    dest_resc = irods_rule_vars['*destResc'][1:-1]
+    dest_obj = irods_rule_vars['*destObj'][1:-1]
 
     ret_val = callback.msiDataObjRsync(source_obj, 'IRODS_TO_IRODS', dest_resc, dest_obj, 0)
     status = ret_val['arguments'][4]

--- a/python_rules/rulemsiDataObjTrim.r
+++ b/python_rules/rulemsiDataObjTrim.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
 
     callback.msiDataObjTrim(source_file, 'null', 'null', '1', 'null', 0)
 

--- a/python_rules/rulemsiDataObjUnlink-trash.r
+++ b/python_rules/rulemsiDataObjUnlink-trash.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    path = global_vars['*Path'][1:-1]
+    path = irods_rule_vars['*Path'][1:-1]
 
     callback.msiDataObjUnlink('objPath=' + path + '++++irodsAdminRmTrash=', 0)
 

--- a/python_rules/rulemsiDataObjUnlink.r
+++ b/python_rules/rulemsiDataObjUnlink.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
 
     callback.msiDataObjUnlink('objPath=' + source_file + '++++forceFlag=', 0)
 

--- a/python_rules/rulemsiDataObjWrite.r
+++ b/python_rules/rulemsiDataObjWrite.r
@@ -1,11 +1,11 @@
 def main(rule_args, callback, rei):
-    obj = global_vars['*Obj'][1:-1]
-    oflags = global_vars['*OFlags'][1:-1]
-    obj_b = global_vars['*ObjB'][1:-1]
-    oflags_b = global_vars['*OFlagsB'][1:-1]
-    offset = global_vars['*Offset'][1:-1]
-    loc = global_vars['*Loc'][1:-1]
-    length = global_vars['*Len'][1:-1]
+    obj = irods_rule_vars['*Obj'][1:-1]
+    oflags = irods_rule_vars['*OFlags'][1:-1]
+    obj_b = irods_rule_vars['*ObjB'][1:-1]
+    oflags_b = irods_rule_vars['*OFlagsB'][1:-1]
+    offset = irods_rule_vars['*Offset'][1:-1]
+    loc = irods_rule_vars['*Loc'][1:-1]
+    length = irods_rule_vars['*Len'][1:-1]
 
     ret_val = callback.msiDataObjOpen(oflags, 0)
     file_desc = ret_val['arguments'][1]

--- a/python_rules/rulemsiDeleteUnusedAVUs.r
+++ b/python_rules/rulemsiDeleteUnusedAVUs.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    condition = global_vars['*arg1'][1:-1]
+    condition = irods_rule_vars['*arg1'][1:-1]
     callback.delayExec(condition, 'callback.msiDeleteUnusedAVUs()', '')
 
 INPUT *arg1 = "<PLUSET>1m</PLUSET><EF>24h</EF>"

--- a/python_rules/rulemsiDigestMonStat.r
+++ b/python_rules/rulemsiDigestMonStat.r
@@ -1,11 +1,11 @@
 def main(rule_args, callback, rei):
-    cpu_weight = global_vars['*Cpuw'][1:-1]
-    mem_weight = global_vars['*Memw'][1:-1]
-    swap_weight = global_vars['*Swapw'][1:-1]
-    run_queue_weight = global_vars['*Runw'][1:-1]
-    disk_weight = global_vars['*Diskw'][1:-1]
-    network_in_weight = global_vars['*Netinw'][1:-1]
-    network_out_weight = global_vars['*Netow'][1:-1]
+    cpu_weight = irods_rule_vars['*Cpuw'][1:-1]
+    mem_weight = irods_rule_vars['*Memw'][1:-1]
+    swap_weight = irods_rule_vars['*Swapw'][1:-1]
+    run_queue_weight = irods_rule_vars['*Runw'][1:-1]
+    disk_weight = irods_rule_vars['*Diskw'][1:-1]
+    network_in_weight = irods_rule_vars['*Netinw'][1:-1]
+    network_out_weight = irods_rule_vars['*Netow'][1:-1]
 
     callback.msiDigestMonStat(cpu_weight, mem_weight, swap_weight, run_queue_weight, disk_weight, network_in_weight, network_out_weight)
 

--- a/python_rules/rulemsiExecGenQuery.r
+++ b/python_rules/rulemsiExecGenQuery.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    coll = global_vars['*Coll'][1:-1]
-    condition = global_vars['*Condition'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    condition = irods_rule_vars['*Condition'][1:-1]
 
     continue_index_old = 1
     count = 0

--- a/python_rules/rulemsiExecStrCondQuery.r
+++ b/python_rules/rulemsiExecStrCondQuery.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    select = global_vars['*Select'][1:-1]
+    select = irods_rule_vars['*Select'][1:-1]
 
     ret_val = callback.msiExecStrCondQuery(select, irods_types.GenQueryOut())
     genQueryOut = ret_val['arguments'][1]

--- a/python_rules/rulemsiFlushMonStat.r
+++ b/python_rules/rulemsiFlushMonStat.r
@@ -1,13 +1,13 @@
 def main(rule_args, callback, rei):
-    time = global_vars['*Time'][1:-1]
-    table = global_vars['*Table'][1:-1]
-    cpu_weight = global_vars['*Cpuw'][1:-1]
-    mem_weight = global_vars['*Memw'][1:-1]
-    swap_weight = global_vars['*Swapw'][1:-1]
-    run_queue_weight = global_vars['*Runw'][1:-1]
-    disk_weight = global_vars['*Diskw'][1:-1]
-    network_in_weight = global_vars['*Netinw'][1:-1]
-    network_out_weight = global_vars['*Netow'][1:-1]
+    time = irods_rule_vars['*Time'][1:-1]
+    table = irods_rule_vars['*Table'][1:-1]
+    cpu_weight = irods_rule_vars['*Cpuw'][1:-1]
+    mem_weight = irods_rule_vars['*Memw'][1:-1]
+    swap_weight = irods_rule_vars['*Swapw'][1:-1]
+    run_queue_weight = irods_rule_vars['*Runw'][1:-1]
+    disk_weight = irods_rule_vars['*Diskw'][1:-1]
+    network_in_weight = irods_rule_vars['*Netinw'][1:-1]
+    network_out_weight = irods_rule_vars['*Netow'][1:-1]
 
     callback.msiFlushMonStat(time, table)
     callback.msiDigestMonStat(cpu_weight, mem_weight, swap_weight, run_queue_weight, disk_weight, network_in_weight, network_out_weight)

--- a/python_rules/rulemsiFreeBuffer.r
+++ b/python_rules/rulemsiFreeBuffer.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    flags = global_vars['*Flags'][1:-1]
-    length = global_vars['*Len'][1:-1]
+    flags = irods_rule_vars['*Flags'][1:-1]
+    length = irods_rule_vars['*Len'][1:-1]
 
     ret_val = callback.msiDataObjOpen(flags, 0)
     file_desc = ret_val['arguments'][1]

--- a/python_rules/rulemsiGetContInxFromGenQueryOut.r
+++ b/python_rules/rulemsiGetContInxFromGenQueryOut.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    coll = global_vars['*Coll'][1:-1]
-    condition = global_vars['*Condition'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    condition = irods_rule_vars['*Condition'][1:-1]
 
     continue_index_old = 1
     count = 0

--- a/python_rules/rulemsiGetMoreRows.r
+++ b/python_rules/rulemsiGetMoreRows.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    coll = global_vars['*Coll'][1:-1]
-    condition = global_vars['*Condition'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    condition = irods_rule_vars['*Condition'][1:-1]
 
     continue_index_old = 1
     count = 0

--- a/python_rules/rulemsiGetObjType.r
+++ b/python_rules/rulemsiGetObjType.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    resource = global_vars['*Resource'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    resource = irods_rule_vars['*Resource'][1:-1]
 
     ret_val = callback.msiGetObjType(source_file, 'dummy_str')
     type_file = ret_val['arguments'][1]

--- a/python_rules/rulemsiGetTaggedValueFromString.r
+++ b/python_rules/rulemsiGetTaggedValueFromString.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    tag = global_vars['*Tag'][1:-1]
-    in_str = global_vars['*Str'][1:-1]
+    tag = irods_rule_vars['*Tag'][1:-1]
+    in_str = irods_rule_vars['*Str'][1:-1]
 
     callback.writeLine('stdout', 'String that is tested is')
     callback.writeLine('stdout', in_str)

--- a/python_rules/rulemsiMakeGenQuery.r
+++ b/python_rules/rulemsiMakeGenQuery.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    coll = global_vars['*Coll'][1:-1]
-    condition = global_vars['*Condition'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    condition = irods_rule_vars['*Condition'][1:-1]
 
     continue_index_old = 1
     count = 0

--- a/python_rules/rulemsiObjStat.r
+++ b/python_rules/rulemsiObjStat.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
 
     import os
     (coll, file) = os.path.split(source_file)

--- a/python_rules/rulemsiPrintGenQueryInp.r
+++ b/python_rules/rulemsiPrintGenQueryInp.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    select = global_vars['*Select'][1:-1]
-    select_add = global_vars['*SelectAdd'][1:-1]
-    fcn = global_vars['*Function'][1:-1]
+    select = irods_rule_vars['*Select'][1:-1]
+    select_add = irods_rule_vars['*SelectAdd'][1:-1]
+    fcn = irods_rule_vars['*Function'][1:-1]
 
     ret_val = callback.msiMakeGenQuery(select, "COLL_NAME like '/tempZone/home/rods/%%'", irods_types.GenQueryInp())
     genQueryInp = ret_val['arguments'][2]

--- a/python_rules/rulemsiRmColl.r
+++ b/python_rules/rulemsiRmColl.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    coll = global_vars['*Coll'][1:-1]
-    flag = global_vars['*Flag'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    flag = irods_rule_vars['*Flag'][1:-1]
 
     callback.msiRmColl(coll, flag, 0)
     

--- a/python_rules/rulemsiSendMail.r
+++ b/python_rules/rulemsiSendMail.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    address = global_vars['*Address'][1:-1]
-    subject = global_vars['*Subject'][1:-1]
-    body = global_vars['*Body'][1:-1]
+    address = irods_rule_vars['*Address'][1:-1]
+    subject = irods_rule_vars['*Subject'][1:-1]
+    body = irods_rule_vars['*Body'][1:-1]
 
     callback.msiSendMail(address, subject, body)
     callback.writeLine('stdout', 'Sent e-mail to ' + address + ' about ' + subject)

--- a/python_rules/rulemsiSetACL.r
+++ b/python_rules/rulemsiSetACL.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    user = global_vars['*User'][1:-1]
-    path = global_vars['*Path'][1:-1]
-    acl = global_vars['*Acl'][1:-1]
+    user = irods_rule_vars['*User'][1:-1]
+    path = irods_rule_vars['*Path'][1:-1]
+    acl = irods_rule_vars['*Acl'][1:-1]
 
     callback.msiSetACL('default', acl, user, path)
 

--- a/python_rules/rulemsiSetQuota.r
+++ b/python_rules/rulemsiSetQuota.r
@@ -1,8 +1,8 @@
 def main(rule_args, callback, rei):
-    type = global_vars['*Type'][1:-1]
-    name = global_vars['*Name'][1:-1]
-    resource = global_vars['*Resource'][1:-1]
-    value = global_vars['*Value'][1:-1]
+    type = irods_rule_vars['*Type'][1:-1]
+    name = irods_rule_vars['*Name'][1:-1]
+    resource = irods_rule_vars['*Resource'][1:-1]
+    value = irods_rule_vars['*Value'][1:-1]
 
     callback.msiSetQuota(type, name, resource, value)
     

--- a/python_rules/rulemsiSetReplComment.r
+++ b/python_rules/rulemsiSetReplComment.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    source_file = global_vars['*SourceFile'][1:-1]
-    comment = global_vars['*Comment'][1:-1]
+    source_file = irods_rule_vars['*SourceFile'][1:-1]
+    comment = irods_rule_vars['*Comment'][1:-1]
 
     callback.msiSetReplComment('null', source_file, '0', comment)
 

--- a/python_rules/rulemsiSleep.r
+++ b/python_rules/rulemsiSleep.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    sec = global_vars['*Sec'][1:-1]
-    microsec = global_vars['*MicroSec'][1:-1]
+    sec = irods_rule_vars['*Sec'][1:-1]
+    microsec = irods_rule_vars['*MicroSec'][1:-1]
 
     import time
     callback.writeLine('stdout', time.ctime())

--- a/python_rules/rulemsiSplitPath.r
+++ b/python_rules/rulemsiSplitPath.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    data_object = global_vars['*dataObject'][1:-1]
+    data_object = irods_rule_vars['*dataObject'][1:-1]
 
     callback.writeLine('stdout', 'Object is ' + data_object)
 

--- a/python_rules/rulemsiSplitPathByKey.r
+++ b/python_rules/rulemsiSplitPathByKey.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*string'][1:-1]
-    separator = global_vars['*separator'][1:-1]
+    in_str = irods_rule_vars['*string'][1:-1]
+    separator = irods_rule_vars['*separator'][1:-1]
 
     callback.writeLine('stdout', 'string is ' + in_str)
     (head, tail) = in_str.rsplit(separator, 1)

--- a/python_rules/rulemsiStrArray2String.r
+++ b/python_rules/rulemsiStrArray2String.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*Str'][1:-1]
+    in_str = irods_rule_vars['*Str'][1:-1]
     
     callback.writeLine('stdout', 'Input string is ' + in_str)
 

--- a/python_rules/rulemsiStrCat.r
+++ b/python_rules/rulemsiStrCat.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    dest = global_vars['*dest'][1:-1]
-    src = global_vars['*source'][1:-1]
+    dest = irods_rule_vars['*dest'][1:-1]
+    src = irods_rule_vars['*source'][1:-1]
 
     callback.writeLine('stdout', 'dest is ' + dest)
     callback.writeLine('stdout', 'source is ' + src)

--- a/python_rules/rulemsiStrchop.r
+++ b/python_rules/rulemsiStrchop.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*StringIn'][1:-1]
+    in_str = irods_rule_vars['*StringIn'][1:-1]
 
     new_str = in_str[:-1]
     callback.writeLine('stdout', 'The input string is :  ' + in_str)

--- a/python_rules/rulemsiString2StrArray.r
+++ b/python_rules/rulemsiString2StrArray.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*Str'][1:-1]
+    in_str = irods_rule_vars['*Str'][1:-1]
     
     callback.writeLine('stdout', 'Input string is ' + in_str)
 

--- a/python_rules/rulemsiStrlen.r
+++ b/python_rules/rulemsiStrlen.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*StringIn'][1:-1]
+    in_str = irods_rule_vars['*StringIn'][1:-1]
 
     length = len(in_str)
 

--- a/python_rules/rulemsiSubstr.r
+++ b/python_rules/rulemsiSubstr.r
@@ -1,7 +1,7 @@
 def main(rule_args, callback, rei):
-    in_str = global_vars['*StringIn'][1:-1]
-    offset_str = global_vars['*Offset'][1:-1]
-    length_str = global_vars['*Length'][1:-1]
+    in_str = irods_rule_vars['*StringIn'][1:-1]
+    offset_str = irods_rule_vars['*Offset'][1:-1]
+    length_str = irods_rule_vars['*Length'][1:-1]
 
     offset = int(offset_str)
     length = int(length_str)

--- a/python_rules/rulemsiTarFileCreate.r
+++ b/python_rules/rulemsiTarFileCreate.r
@@ -1,8 +1,8 @@
 def main(rule_args, callback, rei):
-    file = global_vars['*File'][1:-1]
-    coll = global_vars['*Coll'][1:-1]
-    resc = global_vars['*Resc'][1:-1]
-    flag = global_vars['*Flag'][1:-1]
+    file = irods_rule_vars['*File'][1:-1]
+    coll = irods_rule_vars['*Coll'][1:-1]
+    resc = irods_rule_vars['*Resc'][1:-1]
+    flag = irods_rule_vars['*Flag'][1:-1]
 
     callback.msiTarFileCreate(file, coll, resc, flag)
 

--- a/python_rules/rulemsiWriteRodsLog.r
+++ b/python_rules/rulemsiWriteRodsLog.r
@@ -1,5 +1,5 @@
 def main(rule_args, callback, rei):
-    message = global_vars['*Message'][1:-1]
+    message = irods_rule_vars['*Message'][1:-1]
 
     callback.writeLine('stdout', 'Message is ' + message)
 

--- a/python_rules/rulewriteLine.r
+++ b/python_rules/rulewriteLine.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    where = global_vars['*Where'][1:-1]
-    in_str = global_vars['*StringIn'][1:-1]
+    where = irods_rule_vars['*Where'][1:-1]
+    in_str = irods_rule_vars['*StringIn'][1:-1]
 
     callback.writeLine(where, in_str)
 

--- a/python_rules/rulewriteLine_globalvars.r
+++ b/python_rules/rulewriteLine_globalvars.r
@@ -1,0 +1,10 @@
+# global_vars is deprecated.
+# Remove this test once global_vars is removed
+def main(rule_args, callback, rei):
+    where = global_vars['*Where'][1:-1]
+    in_str = global_vars['*StringIn'][1:-1]
+
+    callback.writeLine(where, in_str)
+
+INPUT *Where="stdout", *StringIn="line"
+OUTPUT ruleExecOut

--- a/python_rules/rulewriteString.r
+++ b/python_rules/rulewriteString.r
@@ -1,6 +1,6 @@
 def main(rule_args, callback, rei):
-    where = global_vars['*Where'][1:-1]
-    in_str = global_vars['*StringIn'][1:-1]
+    where = irods_rule_vars['*Where'][1:-1]
+    in_str = irods_rule_vars['*StringIn'][1:-1]
 
     callback.writeLine(where, in_str + ' cheese')
 


### PR DESCRIPTION
Addresses #183
Companion PR: irods/irods#7446
Companion PR: irods/irods#7447

TODO:
- [x] rename C++ variable `global_vars_python` (as we have decided "global" doesn't really make sense)
- [x] improve code comments
- [x] finalize name of python variable (is `irods_rule_vars` good?)
- [x] write tests
- [x] update existing tests
- update docs
    - [x] update usage of `global_vars`
    - [x] add note about deprecation of `global_vars`
- [x] open issue for eventual removal of deprecated `global_vars`
- [x] run tests