### PR TITLE
[irods/irods#7985] Remove reference to `AclPolicy` in template (main)

### DIFF
--- a/core.py.template
+++ b/core.py.template
@@ -126,9 +126,6 @@ def acRenameLocalZone(rule_args, callback, rei):
 def acGetUserByDN(rule_args, callback, rei):
     pass
 
-def acAclPolicy(rule_args, callback, rei):
-    callback.msiAclPolicy('STRICT')
-
 def acTicketPolicy(rule_args, callback, rei):
     pass
 


### PR DESCRIPTION
Issue quick link: irods/irods#7985.
Companion PR to: irods/irods#8264.

This PR removes a reference to both an msi and a static PEP in `core.py.template`.