### PR TITLE
[irods/irods#7381] Treat CAT_SUCCESS_BUT_WITH_NO_INFO as an error (main)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,8 +315,7 @@ namespace
 
 			const auto err = self.effect_handler(self.rule_name, irods::unpack(rule_args_cpp));
 
-			const auto error_occurred =
-				!err.ok() && err.code() != CAT_NO_ROWS_FOUND && err.code() != CAT_SUCCESS_BUT_WITH_NO_INFO;
+			const auto error_occurred = !err.ok() && err.code() != CAT_NO_ROWS_FOUND;
 
 			bp::list ret_list{};
 			while (!rule_args_cpp.empty()) {


### PR DESCRIPTION
In service of irods/irods#7381

Tests all passed with just this change, but need to add a test. I'm not really sure how to trigger `CAT_SUCCESS_BUT_WITH_NO_INFO` on purpose, so we'll see if the test I write is even valid...