### PR TITLE
[#258] make a test rule for totalrows fix

### DIFF
--- a/genquery.py
+++ b/genquery.py
@@ -183,14 +183,14 @@ class Query(object):
     @property
     def parameters(self): return dict((name,getattr(self,name)) for name in self.__parameter_names)
 
-    def copy(self,**parameter_changes):
-        incorrect = list(k for k in parameter_changes if k not in self.__parameter_names)
+    def copy(self,**options):
+        incorrect = list(k for k in options if k not in self.__parameter_names)
         if incorrect:
             raise GenQuery_Options_Spec_Error('Incorrect option(s) to Query: '+', '.join(incorrect))
-        # let `parameter_changes' override but not duplicate `self.parameters' in the keyword argument list
-        keyword_items_list = list(self.parameters.items())  + list(parameter_changes.items())
+        # let `options' override but not duplicate `self.parameters' in the keyword argument list
+        keyword_items_list = list(self.parameters.items())  + list(options.items())
         return Query(self.callback, **dict(keyword_items_list))
-        #return Query(self.callback, **{**self.parameters, **parameter_changes})
+        #return Query(self.callback, **{**self.parameters, **options})
 
     def exec_if_not_yet_execed(self):
         """Query execution is delayed until the first result or total row count is requested."""

--- a/genquery.py
+++ b/genquery.py
@@ -267,7 +267,8 @@ class Query(object):
                     # So instead, we run the query twice manually. This should
                     # perform only slightly worse.
                     # [1]: https://github.com/irods/irods/blob/4.2.6/plugins/database/src/general_query.cpp#L2393
-                    self._total = self.copy(limit=0, options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
+                    self._total = Query(self.callback, self.columns, self.conditions, limit=0,
+                                        options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
 
         return self._total
 

--- a/genquery.py
+++ b/genquery.py
@@ -267,8 +267,7 @@ class Query(object):
                     # So instead, we run the query twice manually. This should
                     # perform only slightly worse.
                     # [1]: https://github.com/irods/irods/blob/4.2.6/plugins/database/src/general_query.cpp#L2393
-                    self._total = Query(self.callback, self.columns, self.conditions, limit=0,
-                                        options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
+                    self._total = self.copy(limit=0, options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
 
         return self._total
 

--- a/genquery.py
+++ b/genquery.py
@@ -267,7 +267,11 @@ class Query(object):
                     # So instead, we run the query twice manually. This should
                     # perform only slightly worse.
                     # [1]: https://github.com/irods/irods/blob/4.2.6/plugins/database/src/general_query.cpp#L2393
-                    self._total = self.copy(limit=0, options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
+                    self._total = self.copy(
+                        limit=0,
+                        offset=0,
+                        options=self.options|Option.RETURN_TOTAL_ROW_COUNT
+                    ).total_rows()
 
         return self._total
 

--- a/genquery.py
+++ b/genquery.py
@@ -267,11 +267,7 @@ class Query(object):
                     # So instead, we run the query twice manually. This should
                     # perform only slightly worse.
                     # [1]: https://github.com/irods/irods/blob/4.2.6/plugins/database/src/general_query.cpp#L2393
-                    self._total = self.copy(
-                        limit=0,
-                        offset=0,
-                        options=self.options|Option.RETURN_TOTAL_ROW_COUNT
-                    ).total_rows()
+                    self._total = self.copy(limit=0, options=self.options|Option.RETURN_TOTAL_ROW_COUNT).total_rows()
 
         return self._total
 

--- a/genquery.py
+++ b/genquery.py
@@ -183,14 +183,14 @@ class Query(object):
     @property
     def parameters(self): return dict((name,getattr(self,name)) for name in self.__parameter_names)
 
-    def copy(self,**options):
-        incorrect = list(k for k in options if k not in self.__parameter_names)
+    def copy(self,**parameter_changes):
+        incorrect = list(k for k in parameter_changes if k not in self.__parameter_names)
         if incorrect:
             raise GenQuery_Options_Spec_Error('Incorrect option(s) to Query: '+', '.join(incorrect))
-        # let `options' override but not duplicate `self.parameters' in the keyword argument list
-        keyword_items_list = list(self.parameters.items())  + list(options.items())
+        # let `parameter_changes' override but not duplicate `self.parameters' in the keyword argument list
+        keyword_items_list = list(self.parameters.items())  + list(parameter_changes.items())
         return Query(self.callback, **dict(keyword_items_list))
-        #return Query(self.callback, **{**self.parameters, **options})
+        #return Query(self.callback, **{**self.parameters, **parameter_changes})
 
     def exec_if_not_yet_execed(self):
         """Query execution is delayed until the first result or total row count is requested."""

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -1,9 +1,11 @@
 import datetime
 from genquery import Query
+import os
 
 class Err(Exception): pass
 
 def main(rule_args, callback, rei):
+    print_test_vector_and_quit = irods_rule_vars['*PRINT_TEST_VECTOR_AND_QUIT'][1:-1].upper().startswith("Y")
     colls = []
     home='/tempZone/home/rods'
     now = f'{datetime.datetime.now():%s.%f}'
@@ -11,6 +13,8 @@ def main(rule_args, callback, rei):
 
     coll_names_lowercase = ['issue-258-'+str(i) for i in range(n_base_names)]
 
+    # LINE COUNTER
+    n = -1 
     try:
         for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
             retv = callback.msiCollCreate((coll:=f'{home}/{now}/{coll}'), '1', -1)
@@ -19,18 +23,24 @@ def main(rule_args, callback, rei):
             else:
                 colls.append(coll)
 
-        for limit_ in (None, 4, 14):
-            for case_sensitive_ in (False, True):
-                for offset_ in (0,3):
-                    query = Query(
-                        callback,
-                        ["COLL_NAME"],
-                        f"""COLL_NAME like '%/issue%' and COLL_PARENT_NAME = '{home}/{now}'"""
-                        , case_sensitive=case_sensitive_
-                        , offset=offset_
-                        , limit=limit_
-                    )
+# EXPECTED RESULTS FROM THE VARIOUS TEST VECTOR COMBINATIONS: (re-generate using argument '*PRINT_TEST_VECTOR_AND_QUIT="yes"')
+#       {case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}
+#             False           0       None             20                    20          
+#             False           0        4               4                     20          
+#             False           0        14              14                    20          
+#             False           3       None             17                    20          
+#             False           3        4               4                     20          
+#             False           3        14              14                    20          
+#             True            0       None             10                    10          
+#             True            0        4               4                     10          
+#             True            0        14              10                    10          
+#             True            3       None             7                     10          
+#             True            3        4               4                     10          
+#             True            3        14              7                     10          
 
+        for case_sensitive_ in (False, True):
+            for offset_ in (0,3):
+                for limit_ in (None, 4, 14):
                     # We expect double the total number of matching rows for case sensitivity being turned off,
                     # due to the capitalized versions showing up in the query.
                     expected_total_rows = n_base_names * (1 if case_sensitive_ else 2)
@@ -42,20 +52,37 @@ def main(rule_args, callback, rei):
                         limit_ if limit_ is not None else expected_total_rows
                     )
 
+                    if print_test_vector_and_quit:
+                        if 0 == (n:=n+1):
+                            callback.writeLine("stderr", "{case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}")
+                        callback.writeLine("stderr", f"{case_sensitive_!r:^17} {offset_:^9} {limit_!s:^8} {expected_result_rows:^22} {expected_total_rows:^21}")
+                        continue
+
+                    query = Query(
+                        callback,
+                        ["COLL_NAME"],
+                        f"""COLL_NAME like '%/issue%' and COLL_PARENT_NAME = '{home}/{now}'"""
+                        , case_sensitive=case_sensitive_
+                        , offset=offset_
+                        , limit=limit_
+                    )
+
                     # Assert that the combination of options selected returned the expected number of row results.
                     received_result_rows = len(list(query))
                     if received_result_rows != expected_result_rows:
                         raise Err(f'{expected_result_rows=}; {received_result_rows=}')
-            
-                    # Assert that total_rows() properly found how many rows, in all, successfully matched the
-                    # query condition.  This number is actually independent of the values of offset_ and limit_.
+
+                    # Assert that total_rows() correctly found the number of rows actually matching the query condition,
+                    # irrespective of the offset and limit.
                     received_total_rows = query.total_rows()
                     if received_total_rows != expected_total_rows:
                         raise Err(f'{expected_total_rows=}; {received_total_rows=}')
-    except:
+    except Exception as e:
+        callback.writeLine("stderr", f"Exception causing test to fail: {e}")
         return -1
     finally:
-        callback.msiRmColl(f'{home}/{now}','forceFlag=',-1)
+        if not print_test_vector_and_quit:
+            callback.msiRmColl(f'{home}/{now}','forceFlag=',-1)
 
-INPUT null
+INPUT *PRINT_TEST_VECTOR_AND_QUIT="no"
 OUTPUT ruleExecOut

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -9,7 +9,7 @@ def main(rule_args, callback, rei):
     home='/tempZone/home/rods'
     now = f'{datetime.datetime.now():%s.%f}'
     coll_names_lowercase = ['issue-258-'+str(i) for i in range(10)]
-    
+
     try:
         for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
             retv = callback.msiCollCreate((coll:=f'{home}/{now}/{coll}'), '1', -1)

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -14,7 +14,7 @@ def main(rule_args, callback, rei):
     coll_names_lowercase = ['issue-258-'+str(i) for i in range(n_base_names)]
 
     # LINE COUNTER
-    n = -1
+    line_counter = -1
     try:
         for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
             retv = callback.msiCollCreate((coll:=f'{home}/{now}/{coll}'), '1', -1)
@@ -53,7 +53,7 @@ def main(rule_args, callback, rei):
                     )
 
                     if print_test_vector_and_quit:
-                        if 0 == (n:=n+1):
+                        if 0 == (line_counter := line_counter + 1):
                             callback.writeLine("stderr", "{case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}")
                         callback.writeLine("stderr", f"{case_sensitive_!r:^17} {offset_:^9} {limit_!s:^8} {expected_result_rows:^22} {expected_total_rows:^21}")
                         continue

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -8,7 +8,11 @@ def main(rule_args, callback, rei):
     colls = []
     home='/tempZone/home/rods'
     now = f'{datetime.datetime.now():%s.%f}'
-    coll_names_lowercase = ['issue-258-'+str(i) for i in range(10)]
+
+    # Keep the following an even number:
+    n_base_names = 10
+
+    coll_names_lowercase = ['issue-258-'+str(i) for i in range(n_base_names)]
 
     try:
         for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
@@ -18,27 +22,31 @@ def main(rule_args, callback, rei):
             else:
                 colls.append(coll)
 
-        query = Query(
-            callback, ["COLL_NAME","COLL_PARENT_NAME"],
-            f"""COLL_NAME like '%/issue%' and COLL_PARENT_NAME = '{home}/{now}'"""
-            , case_sensitive=False
-            , offset=1
-        )
+        for limit_ in (None, 4, 14):
+            for case_sensitive_ in (False, True):
+                for offset_ in (0,3):
+                    query = Query(
+                        callback,
+                        ["COLL_NAME"],
+                        f"""COLL_NAME like '%/issue%' and COLL_PARENT_NAME = '{home}/{now}'"""
+                        , case_sensitive=case_sensitive_
+                        , offset=offset_
+                        , limit=limit_
+                    )
 
-        rows = list(query)
-        total = query.total_rows()
+                    expected_total_rows = n_base_names * (1 if case_sensitive_ else 2)
+                    expected_result_rows = min(
+                        max(0, expected_total_rows - offset_),
+                        limit_ if limit_ is not None else expected_total_rows
+                    )
 
-        # Assert that offset=1 produced the correct number of row results.
-
-        if len(rows) != len(colls)-1:
-            callback.writeLine('stderr',f'{rows=}')
-            raise Err('Incorrect result')
-
-        # Assert that total_rows found the correct number of total matching rows.
-
-        if total != len(colls):
-            raise Err('Incorrect total')
-
+                    # Assert that offset=1 produced the correct number of row results.
+                    if (got_result_rows:=len(list(query))) != expected_result_rows:
+                        raise Err(f'{expected_result_rows=}; {got_result_rows=}')
+            
+                    # Assert that total_rows found the correct number of total matching rows.
+                    if (got_total_rows:=query.total_rows()) != expected_total_rows:
+                        raise Err(f'{expected_total_rows=}; {got_total_rows=}')
     except:
         return -1
     finally:

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -14,7 +14,7 @@ def main(rule_args, callback, rei):
     coll_names_lowercase = ['issue-258-'+str(i) for i in range(n_base_names)]
 
     # LINE COUNTER
-    n = -1 
+    n = -1
     try:
         for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
             retv = callback.msiCollCreate((coll:=f'{home}/{now}/{coll}'), '1', -1)
@@ -25,18 +25,18 @@ def main(rule_args, callback, rei):
 
 # EXPECTED RESULTS FROM THE VARIOUS TEST VECTOR COMBINATIONS: (re-generate using argument '*PRINT_TEST_VECTOR_AND_QUIT="yes"')
 #       {case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}
-#             False           0       None             20                    20          
-#             False           0        4               4                     20          
-#             False           0        14              14                    20          
-#             False           3       None             17                    20          
-#             False           3        4               4                     20          
-#             False           3        14              14                    20          
-#             True            0       None             10                    10          
-#             True            0        4               4                     10          
-#             True            0        14              10                    10          
-#             True            3       None             7                     10          
-#             True            3        4               4                     10          
-#             True            3        14              7                     10          
+#             False           0       None             20                    20
+#             False           0        4               4                     20
+#             False           0        14              14                    20
+#             False           3       None             17                    20
+#             False           3        4               4                     20
+#             False           3        14              14                    20
+#             True            0       None             10                    10
+#             True            0        4               4                     10
+#             True            0        14              10                    10
+#             True            3       None             7                     10
+#             True            3        4               4                     10
+#             True            3        14              7                     10
 
         for case_sensitive_ in (False, True):
             for offset_ in (0,3):

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -42,7 +42,7 @@ def main(rule_args, callback, rei):
     except:
         return -1
     finally:
-        retv = callback.msiRmColl(f'{home}/{now}','forceFlag=',-1)
+        callback.msiRmColl(f'{home}/{now}','forceFlag=',-1)
 
 INPUT null
 OUTPUT ruleExecOut

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -23,20 +23,20 @@ def main(rule_args, callback, rei):
             else:
                 colls.append(coll)
 
-# EXPECTED RESULTS FROM THE VARIOUS TEST VECTOR COMBINATIONS: (re-generate using argument '*PRINT_TEST_VECTOR_AND_QUIT="yes"')
-#       {case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}
-#             False           0       None             20                    20
-#             False           0        4               4                     20
-#             False           0        14              14                    20
-#             False           3       None             17                    20
-#             False           3        4               4                     20
-#             False           3        14              14                    20
-#             True            0       None             10                    10
-#             True            0        4               4                     10
-#             True            0        14              10                    10
-#             True            3       None             7                     10
-#             True            3        4               4                     10
-#             True            3        14              7                     10
+        # EXPECTED RESULTS FROM THE VARIOUS TEST VECTOR COMBINATIONS: (re-generate using argument '*PRINT_TEST_VECTOR_AND_QUIT="yes"')
+        #       {case_sensitive_} {offset_} {limit_} {expected_result_rows} {expected_total_rows}
+        #             False           0       None             20                    20
+        #             False           0        4               4                     20
+        #             False           0        14              14                    20
+        #             False           3       None             17                    20
+        #             False           3        4               4                     20
+        #             False           3        14              14                    20
+        #             True            0       None             10                    10
+        #             True            0        4               4                     10
+        #             True            0        14              10                    10
+        #             True            3       None             7                     10
+        #             True            3        4               4                     10
+        #             True            3        14              7                     10
 
         for case_sensitive_ in (False, True):
             for offset_ in (0,3):

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -1,0 +1,48 @@
+import datetime
+import pprint as pp
+from genquery import Query, Option, AS_DICT
+
+class Err(Exception): pass
+
+def main(rule_args, callback, rei):
+    colls = []
+    home='/tempZone/home/rods'
+    now = f'{datetime.datetime.now():%s.%f}'
+    coll_names_lowercase = ['issue-258-'+str(i) for i in range(10)]
+    
+    try:
+        for coll in (coll_names_lowercase + [_.capitalize() for _ in coll_names_lowercase]):
+            retv = callback.msiCollCreate((coll:=f'{home}/{now}/{coll}'), '1', -1)
+            if retv['arguments'][2] != 0:
+                raise Err(f'could not create test collection {coll}')
+            else:
+                colls.append(coll)
+
+        query = Query(
+            callback, ["COLL_NAME","COLL_PARENT_NAME"],
+            """COLL_NAME like '%/issue%'"""     f""" and COLL_PARENT_NAME = '{home}/{now}'"""
+            , case_sensitive=False
+            , offset=1
+        )
+
+        rows = list(query)
+        total = query.total_rows()
+
+        # Assert that offset=1 produced the correct number of row results.
+
+        if len(rows) != len(colls)-1:
+            callback.writeLine('stderr',f'{rows=}')
+            raise Err('Incorrect result')
+
+        # Assert that total_rows found the correct number of total matching rows.
+
+        if total != len(colls):
+            raise Err('Incorrect total')
+
+    except:
+        return -1
+    finally:
+        retv = callback.msiRmColl(f'{home}/{now}','forceFlag=',-1)
+
+INPUT null
+OUTPUT ruleExecOut

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -1,6 +1,6 @@
 import datetime
 import pprint as pp
-from genquery import Query, Option, AS_DICT
+from genquery import Query
 
 class Err(Exception): pass
 

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -20,7 +20,7 @@ def main(rule_args, callback, rei):
 
         query = Query(
             callback, ["COLL_NAME","COLL_PARENT_NAME"],
-            """COLL_NAME like '%/issue%'"""     f""" and COLL_PARENT_NAME = '{home}/{now}'"""
+            f"""COLL_NAME like '%/issue%' and COLL_PARENT_NAME = '{home}/{now}'"""
             , case_sensitive=False
             , offset=1
         )

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -1,5 +1,4 @@
 import datetime
-import pprint as pp
 from genquery import Query
 
 class Err(Exception): pass

--- a/python_rules/test_258.r
+++ b/python_rules/test_258.r
@@ -7,8 +7,6 @@ def main(rule_args, callback, rei):
     colls = []
     home='/tempZone/home/rods'
     now = f'{datetime.datetime.now():%s.%f}'
-
-    # Keep the following an even number:
     n_base_names = 10
 
     coll_names_lowercase = ['issue-258-'+str(i) for i in range(n_base_names)]
@@ -33,19 +31,27 @@ def main(rule_args, callback, rei):
                         , limit=limit_
                     )
 
+                    # We expect double the total number of matching rows for case sensitivity being turned off,
+                    # due to the capitalized versions showing up in the query.
                     expected_total_rows = n_base_names * (1 if case_sensitive_ else 2)
+
+                    # We expect this relationship to hold for how offset and limit options affect number of
+                    # matching rows actually returned.
                     expected_result_rows = min(
                         max(0, expected_total_rows - offset_),
                         limit_ if limit_ is not None else expected_total_rows
                     )
 
-                    # Assert that offset=1 produced the correct number of row results.
-                    if (got_result_rows:=len(list(query))) != expected_result_rows:
-                        raise Err(f'{expected_result_rows=}; {got_result_rows=}')
+                    # Assert that the combination of options selected returned the expected number of row results.
+                    received_result_rows = len(list(query))
+                    if received_result_rows != expected_result_rows:
+                        raise Err(f'{expected_result_rows=}; {received_result_rows=}')
             
-                    # Assert that total_rows found the correct number of total matching rows.
-                    if (got_total_rows:=query.total_rows()) != expected_total_rows:
-                        raise Err(f'{expected_total_rows=}; {got_total_rows=}')
+                    # Assert that total_rows() properly found how many rows, in all, successfully matched the
+                    # query condition.  This number is actually independent of the values of offset_ and limit_.
+                    received_total_rows = query.total_rows()
+                    if received_total_rows != expected_total_rows:
+                        raise Err(f'{expected_total_rows=}; {received_total_rows=}')
     except:
         return -1
     finally:


### PR DESCRIPTION
In the extra query step  to implement `total_rows( )`, the `Query( )` constructor call  was altering the `case_sensitive` option unconditionally back to its parameter-default value of `True` of the call signature, rather than preserving the corresponding attribute of that member as it existed in the source object as intended.

What was needed was a "cloning with option diffs" via the already existing (but not well-documented) `copy` method, instead of the direct constructor call.
